### PR TITLE
Fix nil pointer dereference and increase timeout

### DIFF
--- a/local-rt-setup/main.go
+++ b/local-rt-setup/main.go
@@ -23,7 +23,7 @@ import (
 )
 
 const (
-	maxConnectionWaitSeconds = 300
+	maxConnectionWaitSeconds = 600
 	waitSleepIntervalSeconds = 10
 	jfrogHomeEnv             = "JFROG_HOME"
 	licenseEnv               = "RTLIC"
@@ -258,7 +258,7 @@ func runInRetryLoop(doRequest func() (*http.Response, error), successMessage str
 			}
 		}
 	}
-	err = errors.New("could not connect to Artifactory: " + err.Error())
+	err = fmt.Errorf("could not connect to Artifactory: %w", err)
 	return
 }
 


### PR DESCRIPTION
Fix this error:
```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x2 addr=0x18 pc=0x1007c8900]

goroutine 1 [running]:
main.runInRetryLoop(0x100915ee8, {0x1007dc55d, 0x27})
	/Users/runner/go/pkg/mod/github.com/jfrog/jfrog-testing-infra/local-rt-setup@v0.0.0-20241029151256-7a2472463139/main.go:261 +0x1c0
main.generateAccessToken()
	/Users/runner/go/pkg/mod/github.com/jfrog/jfrog-testing-infra/local-rt-setup@v0.0.0-20241029151256-7a2472463139/main.go:324 +0x88
main.setupLocalArtifactory()
	/Users/runner/go/pkg/mod/github.com/jfrog/jfrog-testing-infra/local-rt-setup@v0.0.0-20241029151256-7a2472463139/main.go:135 +0x3a0
main.main()
	/Users/runner/go/pkg/mod/github.com/jfrog/jfrog-testing-infra/local-rt-setup@v0.0.0-20241029151256-7a2472463139/main.go:56 +0x1c
Error: Process completed with exit code 2.
```