### PR TITLE
increase timeout

### DIFF
--- a/local-rt-setup/main.go
+++ b/local-rt-setup/main.go
@@ -23,8 +23,8 @@ import (
 )
 
 const (
-	maxConnectionWaitSeconds = 600
-	waitSleepIntervalSeconds = 10
+	maxConnectionWaitSeconds = 700
+	waitSleepIntervalSeconds = 15
 	jfrogHomeEnv             = "JFROG_HOME"
 	licenseEnv               = "RTLIC"
 	localArtifactoryUrl      = "http://localhost:8081/artifactory/"


### PR DESCRIPTION
Lately, the setup-local Artifactory fails a lot.
I know we already increased the timeout, but I'd like to do this once more.

I believe the issue is not with Artifactory loading itself, but rather just a timeout issue.