### PR TITLE
Temp - change artifactory default version

### DIFF
--- a/local-rt-setup/main.go
+++ b/local-rt-setup/main.go
@@ -34,6 +34,7 @@ const (
 	defaultPassword = "password"
 	// defaultVersion    = "[RELEASE]"
 	// This is a temp patch as the latest release version of artifactory needs extra configuration before it could work.
+	// For more info: https://github.com/jfrog/jfrog-testing-infra/pull/27
 	defaultVersion    = "7.104.15"
 	tokenJson         = "token.json"
 	generateTokenJson = "generate.token.json"

--- a/local-rt-setup/main.go
+++ b/local-rt-setup/main.go
@@ -29,10 +29,12 @@ const (
 	licenseEnv               = "RTLIC"
 	localArtifactoryUrl      = "http://localhost:8081/artifactory/"
 	// #nosec G101 -- False positive - no hardcoded credentials.
-	tokensApi         = "http://localhost:8082/access/api/v1/tokens"
-	defaultUsername   = "admin"
-	defaultPassword   = "password"
-	defaultVersion    = "[RELEASE]"
+	tokensApi       = "http://localhost:8082/access/api/v1/tokens"
+	defaultUsername = "admin"
+	defaultPassword = "password"
+	// defaultVersion    = "[RELEASE]"
+	// This is a temp patch as the latest release version of artifactory needs extra configuration before it could work.
+	defaultVersion    = "7.104.15"
 	tokenJson         = "token.json"
 	generateTokenJson = "generate.token.json"
 	githubEnvFileEnv  = "GITHUB_ENV"


### PR DESCRIPTION
### 🔧 Temporary Patch: Default Artifactory Version Rollback

The latest Artifactory release (`jfrog-artifactory-pro-7.111.4`) fails to start properly due to missing configuration attributes required by our setup process:

```
2025/04/24 10:18:40 failed setting the archive index property - attribute does not exist in configuration
```

Until we update our setup to handle the new configuration structure, this PR temporarily pins the default Artifactory version to `jfrog-artifactory-pro-7.104.15`, which is known to be stable.

